### PR TITLE
ATV Reopen Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@
 ```
 
 ## Android support
-If a mitm client sends their status to RDM we can use the same logic to trigger reboots via the `rebootMonitorURL` endpoint. Currently you must use the `manual_list: true` to supply a custom script via the `reboot_cmd` option to reboot devices. All other endpoints (`reopenMonitorURL`, `reapplySAMMonitorURL`, `brightnessMonitorURL`) are not supported since they are iOS specific. Power relays can be triggered via http calls, custom API methods, and are unique per vendor as such this is a batteries not included option.
+If a mitm client sends their status to RDM we can use the same logic to trigger reopen/reboot via the `reopenMonitorURL`/`rebootMonitorURL` endpoints. You must use the `manual_list: true` to supply a custom script via the `reopen_cmd`/`reboot_cmd` options. All other endpoints (`reapplySAMMonitorURL`, `brightnessMonitorURL`) are not supported since they are iOS specific. Power relays can be triggered via http calls, custom API methods, and are unique per vendor as such this is a batteries not included option. Though, a basic script (`atlas_management.sh`) has been added that uses ADB commands for these requests. Using that script, you can setup the devices.json file with entries like this `{"name":"A001","uuid":"","ecid":"","reopen_cmd":"./atlas_management.sh reopen 192.168.1.2 A001","reboot_cmd":"./atlas_management.sh reboot 192.168.1.2 A001"}`. The variables in the script are "task", "DNS IP", "device name". The DNS IP is optional if your host is able to resolve device names. Otherwise, create a similar script for your setup and needs.
 
 It is recommended that you setup multiple DCMRL instances if running iOS and Android on the same host machine. This allows you to keep the automatic iOS device list detection plus reopen, reapply sam, and brightness commands can all point to one instance. Then Android devices will only receive the reboot commands keeping for clean logs.
 
-For iOS devices please leave `reboot_cmd` empty or delete the line!
+For iOS devices please leave the `reopen_cmd`/`reboot_cmd` empty or delete the line!
 
 ## Troubleshooting
 If the cfgutil from AC2 does not list any devices when you use the `cfgutil list` command, then you may need to upgrade AC2 and reinstall the automation tools.

--- a/atlas_management.sh
+++ b/atlas_management.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Get all text from the input with $@
+# Get the frist word with $1 for the task
+# Get the second word with $2 for the DNS server
+# Remove those from the text so we have the device list
+TEXT=$@
+TASK=$1
+DNS=$2
+DEVICES=${TEXT//$TASK/}
+DEVICES=${DEVICES//$DNS/}
+
+if [[ "$TASK" != "reboot" ]] && [[ "$TASK" != "reopen" ]] && [[ "$TASK" != "update" ]] && [[ "$TASK" != "pogo_version" ]]
+then
+	echo Unsupported task: $TASK
+	exit
+fi
+
+for D in $DEVICES
+do
+	IP=$(nslookup $D $DNS | grep Address | tail -1 | awk '{print $2}')
+	echo Connecting to $D at $IP to $TASK
+	adb connect $IP
+	sleep 3
+	if [[ "$TASK" = 'reopen' ]]
+	then
+		adb -s $IP shell su -c 'am force-stop com.nianticlabs.pokemongo && am force-stop com.pokemod.atlas && am startservice com.pokemod.atlas/com.pokemod.atlas.services.MappingService'
+	elif [[ "$TASK" = 'reboot' ]]
+	then
+		adb -s $IP shell su -c 'reboot'
+	elif [[ "$TASK" = 'update' ]]
+	then
+		adb -s $IP shell su -c "./system/bin/atlas.sh -ua"
+	elif [[ "$TASK" = 'pogo_version' ]]
+	then
+		adb -s $IP shell su -c 'tac /data/local/tmp/atlas.log | grep -m 1 Using'
+	fi
+	sleep 3
+	adb disconnect $IP
+done
+

--- a/devices.example.json
+++ b/devices.example.json
@@ -10,7 +10,8 @@
     "uuid":"",
     "ecid":"",
     "ipaddr":"192.168.1.1",
-    "reboot_cmd": "./custom_reboot.sh atv-01"
+    "reopen_cmd": "./custom_reboot.sh reopen atv-01",
+    "reboot_cmd": "./custom_reboot.sh reboot atv-01"
   },
   {
     "name":"002-SE",

--- a/listener.js
+++ b/listener.js
@@ -48,9 +48,9 @@ server.post("/", (payload, res) => {
             case "restart":
                 if (device.name == target.device) {
                     if (device.reboot_cmd) {
-                        var command = device.reboot_cmd
+                        var command = device.reboot_cmd;
                     } else {
-                        var command = `idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`
+                        var command = `idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`;
                     }
                     let restart = await cli_exec(command, "device_command");
 
@@ -92,7 +92,13 @@ server.post("/", (payload, res) => {
                             ipaddr = await cli_exec("grep -A1 \"" + device.name.replace('+', '.*') + "\" /var/db/dhcpd_leases", 'device_ipaddr');
                         }
                     }
-                    const reopen = await cli_exec("curl --connect-timeout 10 -m 10 http://" + ipaddr + ":8080/restart", "device_command");
+                    if (device.reopen_cmd) {
+                        var reopen = await cli_exec(device.reopen_cmd, "device_command");
+                        console.log(reopen.result);
+                    } 
+                    else {
+                        var reopen = await cli_exec("curl --connect-timeout 10 -m 10 http://" + ipaddr + ":8080/restart", "device_command");
+                    }
 
                     // THERE WAS AN ERROR WITH CURL
                     if (reopen.hasError) {


### PR DESCRIPTION
This update adds the option to have the `reopen` trigger work for ATVs. I've also added an ADB script that can be used for reopen/reboot along with a few other commands that are not implemented in the listener.